### PR TITLE
support install movienet-tools without torch

### DIFF
--- a/movienet/tools/__init__.py
+++ b/movienet/tools/__init__.py
@@ -1,10 +1,4 @@
 from .crawler import DoubanCrawler, IMDBCrawler, TMDBCrawler
-from .detector import DistPersonDetector, FaceDetector, PersonDetector
-from .extractor import (AudioExtractor, DistAudioExtractor,
-                        DistPersonExtractor, DistPlaceExtractor, FaceExtractor,
-                        PersonExtractor, PlaceExtractor)
-from .action_extractor import ActionExtractor
-from .metaio import MetaParser
 from .movie import (MovieReader, concat_movie, convert_movie,
                     cut_movie_by_time, frames_to_seconds, resize_movie,
                     seconds_to_frames, seconds_to_timecode,
@@ -12,13 +6,30 @@ from .movie import (MovieReader, concat_movie, convert_movie,
 from .shotdetect import ShotDetector
 from .version import __version__, short_version
 
-__all__ = [
-    '__version__', 'short_version', 'DoubanCrawler', 'IMDBCrawler',
-    'TMDBCrawler', 'MetaParser', 'MovieReader', 'ShotDetector',
-    'convert_movie', 'resize_movie', 'cut_movie_by_time', 'concat_movie',
-    'seconds_to_timecode', 'seconds_to_frames', 'frames_to_seconds',
-    'timecode_to_seconds', 'PersonDetector', 'DistPersonDetector',
-    'PlaceExtractor', 'DistPlaceExtractor', 'AudioExtractor',
-    'DistAudioExtractor', 'PersonExtractor', 'DistPersonExtractor',
-    'FaceDetector', 'FaceExtractor', 'ActionExtractor'
-]
+try:
+    import torch
+except ImportError:
+    __all__ = [
+        '__version__', 'short_version', 'DoubanCrawler', 'IMDBCrawler',
+        'TMDBCrawler', 'MovieReader', 'ShotDetector', 'convert_movie',
+        'resize_movie', 'cut_movie_by_time', 'concat_movie',
+        'seconds_to_timecode', 'seconds_to_frames', 'frames_to_seconds',
+        'timecode_to_seconds'
+    ]
+else:
+    from .detector import DistPersonDetector, FaceDetector, PersonDetector
+    from .extractor import (AudioExtractor, DistAudioExtractor,
+                            DistPersonExtractor, DistPlaceExtractor,
+                            FaceExtractor, PersonExtractor, PlaceExtractor)
+    from .action_extractor import ActionExtractor
+    from .metaio import MetaParser
+    __all__ = [
+        '__version__', 'short_version', 'DoubanCrawler', 'IMDBCrawler',
+        'TMDBCrawler', 'MetaParser', 'MovieReader', 'ShotDetector',
+        'convert_movie', 'resize_movie', 'cut_movie_by_time', 'concat_movie',
+        'seconds_to_timecode', 'seconds_to_frames', 'frames_to_seconds',
+        'timecode_to_seconds', 'PersonDetector', 'DistPersonDetector',
+        'PlaceExtractor', 'DistPlaceExtractor', 'AudioExtractor',
+        'DistAudioExtractor', 'PersonExtractor', 'DistPersonExtractor',
+        'FaceDetector', 'FaceExtractor', 'ActionExtractor'
+    ]

--- a/movienet/tools/version.py
+++ b/movienet/tools/version.py
@@ -1,5 +1,5 @@
 # GENERATED VERSION FILE
-# TIME: Fri Jul 17 20:30:40 2020
+# TIME: Sun Sep  6 16:27:34 2020
 
-__version__ = '0.1rc1+1661530'
+__version__ = '0.1rc1+4e11630'
 short_version = '0.1rc1'

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,15 @@ from setuptools import Extension, dist, find_namespace_packages, setup
 import Cython.Compiler.Options
 import numpy as np  # noqa: E402
 from Cython.Build import cythonize  # noqa: E402
-from torch.utils.cpp_extension import BuildExtension, CUDAExtension
+# from torch.utils.cpp_extension import BuildExtension, CUDAExtension
+EXT_TYPE = ''
+try:
+    import torch
+    from torch.utils.cpp_extension import BuildExtension
+    EXT_TYPE = 'pytorch'
+except ModuleNotFoundError:
+    from Cython.Distutils import build_ext as BuildExtension
+    print('Skip building ext ops due to the absence of torch.')
 
 Cython.Compiler.Options.docstrings = False
 
@@ -200,6 +208,6 @@ if __name__ == '__main__':
                 name='roi_pool_cuda',
                 module='movienet.tools.action_extractor.core.ops.roi_pool',
                 sources=['src/roi_pool_cuda.cpp', 'src/roi_pool_kernel.cu'])
-        ],
+        ] if EXT_TYPE else [],
         cmdclass={'build_ext': BuildExtension},
         zip_safe=False)


### PR DESCRIPTION
Support install ``movienet-tools`` without ``torch`` as a dependency.
This allow the users to quickly use part of the tools from ``movienet-tools``, e.g., ``ShotDetector``.

If ``Pytorch`` is not installed, all the feature extractors and detectors will be invalid.